### PR TITLE
Support Go Modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/processone/mpg123
+
+go 1.9


### PR DESCRIPTION
Hello,

Please consider supporting [Go Modules], the new packaging standard that will be on by default Go 1.12. Experimental support is in Go 1.11 and the new module paths are supported in Go 1.9.7+ and Go 1.10.3+ in a read-only manner for backwards compatibility with all supported versions of Go.

Because this library is still below version 2, and has no external dependencies, the [`go.mod`] file is fairly simple. If you accept this PR, the only other thing to do would be to start using semver compatible tags and tag a release of this library that others can pin to (for example `v0.0.1` or `v1.0.0`).

Note that I set the language version go 1.9 in the mod file because 1.9.7 is the earliest version with partial support for reading the `go.mod` file (earlier versions will keep working as they always have and won't read the go.mod file) and it did not appear that you were using any standard library or language features introduced after 1.9 (it builds fine with 1.9.7).

Using modules if future changes are made to this library is relatively simple; `go get -u` on Go 1.11 with modules on or 1.12 by default will update dependencies (not a problem here), and `go mod tidy` will trim down any dependencies that have been removed from the `go.mod` file and `go.sum` file (which doesn't exist because there are no dependencies; it's nice to be lean!). I'd be happy to provide more information, or a quick crash course in using modules if you want to familiarize yourself with them, but of course there's not much to do for this library.

Thank you for your consideration.

[Go Modules]: https://github.com/golang/go/wiki/Modules
[`go.mod`]: https://tip.golang.org/cmd/go/#hdr-The_go_mod_file